### PR TITLE
Add influxdb version to .env-default

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -8,6 +8,7 @@ KAPACITOR_HOST=kapacitor.company.io
 LETSENCRYPT_EMAIL=contact@company.io
 
 # Influxdb
+INFLUXDB_VERSION=1.5-alpine
 INFLUXDB_DB=telegraf
 INFLUXDB_ADMIN_USER=admin
 INFLUXDB_ADMIN_PASSWORD=foopassword


### PR DESCRIPTION
make step fails since the environment variable for INFLUXDB_VERSION isn't specified.